### PR TITLE
[AWX] Fix contrib AWX helm charts

### DIFF
--- a/kubernetes/contrib/components/awx/templates/configmap.yaml
+++ b/kubernetes/contrib/components/awx/templates/configmap.yaml
@@ -144,3 +144,95 @@ data:
           {"vhost":"{{ .Values.config.rabbitmqVhost }}","name":"ha-all","pattern":".*","definition":{"ha-mode":"all","ha-sync-mode":"automatic"}}
       ]
     }
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.fullname" . }}-nginx-conf
+  namespace: {{ include "common.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "common.name" . }}
+    helm.sh/chart: {{ include "common.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  nginx.conf: |
+    worker_processes  1;
+    pid        /tmp/nginx.pid;
+    events {
+        worker_connections  1024;
+    }
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+        server_tokens off;
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+        access_log /dev/stdout main;
+        map $http_upgrade $connection_upgrade {
+            default upgrade;
+            ''      close;
+        }
+        sendfile        on;
+        #tcp_nopush     on;
+        #gzip  on;
+        upstream uwsgi {
+            server 127.0.0.1:8050;
+            }
+        upstream daphne {
+            server 127.0.0.1:8051;
+        }
+        server {
+            listen 8052 default_server;
+            # If you have a domain name, this is where to add it
+            server_name _;
+            keepalive_timeout 65;
+            # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+            add_header Strict-Transport-Security max-age=15768000;
+            add_header Content-Security-Policy "default-src 'self'; connect-src 'self' ws: wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.pendo.io; img-src 'self' *.pendo.io data:; report-uri /csp-violation/";
+            add_header X-Content-Security-Policy "default-src 'self'; connect-src 'self' ws: wss:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.pendo.io; img-src 'self' *.pendo.io data:; report-uri /csp-violation/";
+            # Protect against click-jacking https://www.owasp.org/index.php/Testing_for_Clickjacking_(OTG-CLIENT-009)
+            add_header X-Frame-Options "DENY";
+            location /nginx_status {
+              stub_status on;
+              access_log off;
+              allow 127.0.0.1;
+              deny all;
+            }
+            location /static/ {
+                alias /var/lib/awx/public/static/;
+            }
+            location /favicon.ico { alias /var/lib/awx/public/static/favicon.ico; }
+            location /websocket {
+                # Pass request to the upstream alias
+                proxy_pass http://daphne;
+                # Require http version 1.1 to allow for upgrade requests
+                proxy_http_version 1.1;
+                # We want proxy_buffering off for proxying to websockets.
+                proxy_buffering off;
+                # http://en.wikipedia.org/wiki/X-Forwarded-For
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                # enable this if you use HTTPS:
+                proxy_set_header X-Forwarded-Proto https;
+                # pass the Host: header from the client for the sake of redirects
+                proxy_set_header Host $http_host;
+                # We've set the Host header, so we don't need Nginx to muddle
+                # about with redirects
+                proxy_redirect off;
+                # Depending on the request value, set the Upgrade and
+                # connection headers
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+            }
+            location / {
+                # Add trailing / if missing
+                rewrite ^(.*)$http_host(.*[^/])$ $1$http_host$2/ permanent;
+                uwsgi_read_timeout 120s;
+                uwsgi_pass uwsgi;
+                include /etc/nginx/uwsgi_params;
+                proxy_set_header X-Forwarded-Port 443;
+            }
+        }
+    }

--- a/kubernetes/contrib/components/awx/templates/statefulset.yaml
+++ b/kubernetes/contrib/components/awx/templates/statefulset.yaml
@@ -82,6 +82,10 @@ spec:
           name: awx-secret-key
           readOnly: true
           subPath: SECRET_KEY
+        - mountPath: /etc/nginx/nginx.conf
+          name: awx-nginx-conf
+          subPath: "nginx.conf"
+
       - command: ["/bin/sh","-c"]
         args: ["/usr/bin/launch_awx_task.sh"]
         env:
@@ -109,6 +113,9 @@ spec:
           name: awx-secret-key
           readOnly: true
           subPath: SECRET_KEY
+        - mountPath: /etc/nginx/nginx.conf
+          name: awx-nginx-conf
+          subPath: "nginx.conf"
       - env:
         - name: MY_POD_IP
           valueFrom:
@@ -209,5 +216,12 @@ spec:
             path: rabbitmq_definitions.json
           name: {{ include "common.fullname" . }}-rabbitmq
         name: rabbitmq-config
+      - configMap:
+          defaultMode: 420
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+          name: {{ include "common.fullname" . }}-nginx-conf
+        name: awx-nginx-conf
       imagePullSecrets:
       - name: "{{ include "common.namespace" . }}-docker-registry-key"

--- a/kubernetes/contrib/components/awx/values.yaml
+++ b/kubernetes/contrib/components/awx/values.yaml
@@ -95,7 +95,7 @@ service:
     type: NodePort
     portName: web
     internalPort: 8052
-    externalPort: 80
+    externalPort: 8052
     nodePort: 78
   rabbitmq:
     type: ClusterIP


### PR DESCRIPTION
Add configmap to ensure nginx binds correctly through port 8052

Previously, nginx attempted to bing through port 80 (since it is using a default config file) which requires privileged rights.

Associated Jira ticket : https://jira.onap.org/browse/INT-1858